### PR TITLE
Fix token_type_ids mismatch in codebert-retrain notebook

### DIFF
--- a/notebook/codebert-retrain-fixed.ipynb
+++ b/notebook/codebert-retrain-fixed.ipynb
@@ -1,0 +1,142 @@
+{
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  },
+  "kaggle": {
+   "accelerator": "none",
+   "dataSources": [],
+   "dockerImageVersionId": 31011,
+   "isInternetEnabled": true,
+   "language": "python",
+   "sourceType": "notebook",
+   "isGpuEnabled": false
+  }
+ },
+ "nbformat_minor": 4,
+ "nbformat": 4,
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": "# Enhanced CodeBERT for Swift Code Understanding (Fixed Version)\n\nThis is a fixed version of the original notebook that addresses the token_type_ids mismatch issue when using extended position embeddings.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "# Install required libraries\n!pip install transformers datasets evaluate torch scikit-learn tqdm dropbox requests\n",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "# Important: These imports must be properly separated\nimport os\nimport json\nimport torch\nimport random\nimport numpy as np\nimport time\nimport gc\nimport re\nimport collections\nimport psutil  # Add psutil for memory monitoring\nfrom tqdm.auto import tqdm\nfrom datasets import load_dataset, ClassLabel\nfrom sklearn.metrics import accuracy_score, f1_score, precision_recall_fscore_support\nfrom sklearn.utils.class_weight import compute_class_weight\nfrom torch.utils.data import DataLoader, Dataset, RandomSampler, SequentialSampler\nfrom transformers import (\n    AutoTokenizer, \n    AutoModelForSequenceClassification,\n    RobertaForSequenceClassification,\n    Trainer, \n    TrainingArguments,\n    set_seed,\n    DataCollatorWithPadding,\n    EarlyStoppingCallback,\n    get_scheduler\n)\n\n# Import AdamW from torch.optim instead of transformers.optimization\nfrom torch.optim import AdamW\nfrom transformers.trainer_utils import get_last_checkpoint\n\n# Set a seed for reproducibility\nset_seed(42)\n\n# Add memory management function with more detailed reporting\ndef cleanup_memory():\n    \"\"\"Force garbage collection and clear CUDA cache if available.\"\"\"\n    # Get memory usage before cleanup\n    before = psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2\n    \n    # Perform cleanup\n    gc.collect()\n    if torch.cuda.is_available():\n        torch.cuda.empty_cache()\n    \n    # Get memory usage after cleanup\n    after = psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2\n    print(f\"Memory cleaned up. Before: {before:.2f} MB, After: {after:.2f} MB, Freed: {before - after:.2f} MB\")\n    \n    # Print system memory info\n    mem = psutil.virtual_memory()\n    print(f\"System memory: {mem.percent}% used, {mem.available / 1024 / 1024:.2f} MB available\")\n",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "# Check if GPU is available\nimport torch\n\nif torch.cuda.is_available():\n    device = torch.device('cuda')\n    print(f\"Using GPU: {torch.cuda.get_device_name(0)}\")\nelse:\n    device = torch.device('cpu')\n    print(\"Using CPU - Note: Training will be much slower on CPU\")\n\n# Set random seeds for reproducibility\nSEED = 42\nrandom.seed(SEED)\nnp.random.seed(SEED)\ntorch.manual_seed(SEED)\nif torch.cuda.is_available():\n    torch.cuda.manual_seed_all(SEED)\n",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## Dataset and Model Configuration\n\nLet's define the model and dataset we'll be using, with reduced batch size for CPU training:",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "# Dataset configuration\nDATASET_ID = \"mvasiliniuc/iva-swift-codeint\"# Model configuration - reduced batch size and epochs for debugging\nMODEL_NAME = \"Ct1tz/Codebert-Base-B2D4G5\"\nMAX_LENGTH = 10000  # Extended from 512 to 10000 tokens\nBATCH_SIZE = 16  # Reduced from 16 to 4 for CPU training\nLEARNING_RATE = 2e-5\nWEIGHT_DECAY = 0.01\nNUM_EPOCHS = 5  # Reduced from 5 to 1 for debugging\nWARMUP_STEPS = 500  # Reduced from 500 to 100\nGRADIENT_ACCUMULATION_STEPS = 4  # Reduced from 4 to 2\n# Add a small dataset size for debugging\nDEBUG_MODE = False  # Set to False for full training\nDEBUG_SAMPLE_SIZE = 500  # Number of examples to use in debug mode\nprint(\"Using debug configuration with reduced parameters for CPU training.\")",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "# Function to load dataset with retry logic\ndef load_dataset_with_retry(dataset_id, max_retries=3, retry_delay=5):\n    \"\"\"Load a dataset with retry logic.\"\"\"\n    for attempt in range(max_retries):\n        try:\n            print(f\"Loading dataset (attempt {attempt+1}/{max_retries})...\")\n            data = load_dataset(dataset_id, trust_remote_code=True)\n            print(f\"Dataset loaded successfully with {len(data['train'])} examples\")\n            return data\n        except Exception as e:\n            print(f\"Error loading dataset (attempt {attempt+1}/{max_retries}): {e}\")\n            if attempt < max_retries - 1:\n                print(f\"Retrying in {retry_delay} seconds...\")\n                time.sleep(retry_delay)\n            else:\n                print(\"Maximum retries reached. Could not load dataset.\")\n                raise\n\n# Load the dataset with retry logic\ntry:\n    print(f\"Loading dataset: {DATASET_ID}\")\n    data = load_dataset_with_retry(DATASET_ID)\n    print(\"Dataset structure:\")\n    print(data)\n    \n    # If in debug mode, take a small sample of the dataset\n    if DEBUG_MODE and 'train' in data:\n        print(f\"DEBUG MODE: Sampling {DEBUG_SAMPLE_SIZE} examples from dataset\")\n        # Take a stratified sample if possible\n        data['train'] = data['train'].shuffle(seed=42).select(range(min(DEBUG_SAMPLE_SIZE, len(data['train']))))\n        print(f\"Reduced dataset size: {len(data['train'])} examples\")\n        \nexcept Exception as e:\n    print(f\"Fatal error loading dataset: {e}\")\n    raise\n",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "# Verify dataset structure and column names\ndef verify_dataset_structure(dataset):\n    \"\"\"Verify that the dataset has the expected structure and columns.\"\"\"\n    required_columns = ['repo_name', 'path', 'content']\n    if 'train' not in dataset:\n        print(\"WARNING: Dataset does not have a 'train' split.\")\n        return False\n    \n    missing_columns = [col for col in required_columns if col not in dataset['train'].column_names]\n    if missing_columns:\n        print(f\"WARNING: Dataset is missing required columns: {missing_columns}\")\n        return False\n    \n    print(\"Dataset structure verification passed.\")\n    return True\n\n# Verify dataset structure\ndataset_valid = verify_dataset_structure(data)\nif not dataset_valid:\n    print(\"Dataset structure is not as expected. Proceeding with caution.\")\n",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "# Load the CodeBERT tokenizer with error handling\ntry:\n    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME, model_max_length=MAX_LENGTH)\n    print(f\"Tokenizer vocabulary size: {len(tokenizer)}\")\n    print(f\"Tokenizer type: {tokenizer.__class__.__name__}\")\nexcept Exception as e:\n    print(f\"Error loading tokenizer: {e}\")\n    raise",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "def extract_file_type(path):\n    \"\"\"\n    Extract the file type/category based on the file path and naming conventions in Swift projects.\n    \n    Args:\n        path (str): The file path\n        \n    Returns:\n        int: The category label (0-5)\n    \"\"\"\n    path_lower = path.lower()\n    filename = path.split('/')[-1].lower()\n    \n    # Category 0: Models - Data structures and model definitions\n    if ('model' in path_lower or \n        'struct' in path_lower or \n        'entity' in path_lower or\n        'data' in path_lower and 'class' in path_lower):\n        return 0\n    \n    # Category 1: Views - UI related files\n    elif ('view' in path_lower or \n          'ui' in path_lower or \n          'screen' in path_lower or \n          'page' in path_lower or\n          'controller' in path_lower and 'view' in path_lower):\n        return 1\n    \n    # Category 2: Controllers - Application logic\n    elif ('controller' in path_lower or \n          'manager' in path_lower or \n          'coordinator' in path_lower or\n          'service' in path_lower):\n        return 2\n    \n    # Category 3: Utilities - Helper functions and extensions\n    elif ('util' in path_lower or \n          'helper' in path_lower or \n          'extension' in path_lower or\n          'common' in path_lower):\n        return 3\n    \n    # Category 4: Tests - Test files\n    elif ('test' in path_lower or \n          'spec' in path_lower or \n          'mock' in path_lower):\n        return 4\n    \n    # Category 5: Configuration - Package and configuration files\n    elif ('package.swift' in path_lower or \n          'config' in path_lower or \n          'settings' in path_lower or\n          'info.plist' in path_lower):\n        return 5\n    \n    # Default to category 3 (Utilities) if no clear category is found\n    return 3\n\n# Apply the function to create labels\ntry:\n    # Create a new column with the extracted labels\n    labeled_data = data['train'].map(lambda example: {\n        **example,\n        'label': extract_file_type(example['path'])\n    })\n    \n    # Count the distribution of labels\n    label_counts = collections.Counter(labeled_data['label'])\n    \n    # Define category names for better readability\n    category_names = {\n        0: \"Models\",\n        1: \"Views\",\n        2: \"Controllers\",\n        3: \"Utilities\",\n        4: \"Tests\",\n        5: \"Configuration\"\n    }\n    \n    print(\"Label distribution:\")\n    for label, count in sorted(label_counts.items()):\n        category_name = category_names.get(label, f\"Unknown-{label}\")\n        print(f\"Label {label} ({category_name}): {count} examples ({count/len(labeled_data)*100:.2f}%)\")\n    \n    # Get unique labels\n    unique_labels = sorted(label_counts.keys())\n    num_labels = len(unique_labels)\n    \n    print(f\"\\nTotal unique labels: {num_labels}\")\nexcept Exception as e:\n    print(f\"Error in data preparation: {e}\")\n    raise\n",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "# Split the data into train, validation, and test sets\ntry:\n    # Shuffle the data\n    shuffled_data = labeled_data.shuffle(seed=42)\n    \n    # Split into train (80%), validation (10%), and test (10%)\n    train_size = int(0.8 * len(shuffled_data))\n    val_size = int(0.1 * len(shuffled_data))\n    \n    train_data = shuffled_data.select(range(train_size))\n    val_data = shuffled_data.select(range(train_size, train_size + val_size))\n    test_data = shuffled_data.select(range(train_size + val_size, len(shuffled_data)))\n    \n    print(f\"Training set size: {len(train_data)}\")\n    print(f\"Training set label distribution: {collections.Counter(train_data['label'])}\")\n    print(f\"Validation set size: {len(val_data)}\")\n    print(f\"Validation set label distribution: {collections.Counter(val_data['label'])}\")\n    print(f\"Test set size: {len(test_data)}\")\n    print(f\"Test set label distribution: {collections.Counter(test_data['label'])}\")\nexcept Exception as e:\n    print(f\"Error splitting data: {e}\")\n    raise\n",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "# Tokenize the data\ndef tokenize_function(examples):\n    \"\"\"Tokenize the code content with proper truncation.\"\"\"\n    # Tokenize the code content\n    return tokenizer(\n        examples['content'],\n        padding='max_length',\n        truncation=True,\n        max_length=MAX_LENGTH,\n        return_tensors=\"pt\"\n    )\n\ntry:\n    # Apply tokenization to each split\n    tokenized_train_data = train_data.map(\n        tokenize_function,\n        batched=True,\n        remove_columns=['repo_name', 'path', 'content']\n    )\n    \n    tokenized_val_data = val_data.map(\n        tokenize_function,\n        batched=True,\n        remove_columns=['repo_name', 'path', 'content']\n    )\n    \n    tokenized_test_data = test_data.map(\n        tokenize_function,\n        batched=True,\n        remove_columns=['repo_name', 'path', 'content']\n    )\n    \n    print(f\"Tokenized {len(tokenized_train_data)} training examples\")\n    print(f\"Tokenized {len(tokenized_val_data)} validation examples\")\n    print(f\"Tokenized {len(tokenized_test_data)} test examples\")\n    \n    # Set the format for PyTorch\n    tokenized_train_data.set_format(\"torch\")\n    tokenized_val_data.set_format(\"torch\")\n    tokenized_test_data.set_format(\"torch\")\n    \n    print(\"Data tokenization complete\")\nexcept Exception as e:\n    print(f\"Error tokenizing data: {e}\")\n    raise\n",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "try:\n    # Load the model with the correct number of labels\n    model = AutoModelForSequenceClassification.from_pretrained(\n        MODEL_NAME, \n        num_labels=num_labels,\n        problem_type=\"single_label_classification\"\n    )\n    \n    # Move model to the appropriate device\n    model.to(device)\n    \n    # Extend position embeddings to support longer sequences\n    if MAX_LENGTH > 512:\n        print(f\"Extending position embeddings from {model.config.max_position_embeddings} to {MAX_LENGTH}\")\n        # Get current position embeddings\n        current_max_pos = model.config.max_position_embeddings\n        # Initialize new position embeddings for the extended range\n        new_pos_embed = model.roberta.embeddings.position_embeddings.weight.new_empty(MAX_LENGTH, model.config.hidden_size)\n        # Copy existing weights\n        new_pos_embed[:current_max_pos] = model.roberta.embeddings.position_embeddings.weight\n        # Initialize remaining weights (interpolation, repeating pattern, or just xavier init)\n        # Using Xavier initialization for the remainder\n        import torch.nn as nn\n        nn.init.xavier_uniform_(new_pos_embed[current_max_pos:])\n        # Update the model config\n        model.config.max_position_embeddings = MAX_LENGTH\n        # Replace the position embeddings weights\n        model.roberta.embeddings.position_embeddings = nn.Embedding.from_pretrained(new_pos_embed, freeze=False)\n        # Update the position_ids in the model to work with new length\n        model.roberta.embeddings.register_buffer(\n            \"position_ids\", torch.arange(MAX_LENGTH).expand((1, -1))\n        )\n        \n        # Fix for token_type_ids buffer - create a new buffer with the correct size\n        if hasattr(model.roberta.embeddings, \"token_type_ids\"):\n            # Get the original token_type_ids\n            orig_token_type_ids = model.roberta.embeddings.token_type_ids\n            # Create a new buffer with the extended size\n            new_token_type_ids = torch.zeros(1, MAX_LENGTH, dtype=torch.long, device=orig_token_type_ids.device)\n            # Copy the original values\n            new_token_type_ids[:, :orig_token_type_ids.size(1)] = orig_token_type_ids\n            # Register the new buffer\n            model.roberta.embeddings.register_buffer(\"token_type_ids\", new_token_type_ids)\n            print(f\"Extended token_type_ids from size {orig_token_type_ids.size()} to {new_token_type_ids.size()}\")\n        \n        print(\"Successfully extended position embeddings\")\n    \n    print(f\"Model loaded with {num_labels} output classes\")\n    print(f\"Model type: {model.__class__.__name__}\")\n    \n    # Print model size\n    model_size = sum(p.numel() for p in model.parameters())\n    print(f\"Model has {model_size:,} parameters\")\n    \n    # Check memory usage\n    process = psutil.Process(os.getpid())\n    memory_info = process.memory_info()\n    print(f\"Current memory usage: {memory_info.rss / 1024 / 1024:.2f} MB\")\nexcept Exception as e:\n    print(f\"Error loading model: {e}\")\n    raise",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "# Compute class weights to handle imbalanced data\ntry:\n    # Extract labels for computing class weights\n    labels = train_data['label']\n    \n    # Compute balanced class weights\n    class_weights = compute_class_weight('balanced', classes=np.unique(labels), y=labels)\n    class_weights = torch.tensor(class_weights, dtype=torch.float).to(device)\n    \n    print(\"Class weights:\")\n    for i, weight in enumerate(class_weights):\n        category_name = category_names.get(i, f\"Unknown-{i}\")\n        print(f\"Class {i} ({category_name}): {weight:.4f}\")\nexcept Exception as e:\n    print(f\"Error computing class weights: {e}\")\n    raise\n",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "# Define a custom trainer with weighted loss and progress tracking\nclass DebugTrainer(Trainer):\n    def __init__(self, *args, **kwargs):\n        super().__init__(*args, **kwargs)\n        self.step_counter = 0\n        self.last_log_time = time.time()\n        \n    def compute_loss(self, model, inputs, return_outputs=False, **kwargs):\n        # Track progress\n        self.step_counter += 1\n        current_time = time.time()\n        \n        # Log every 10 steps or if more than 30 seconds have passed\n        if self.step_counter % 1000 == 0 or (current_time - self.last_log_time) > 30:\n            process = psutil.Process(os.getpid())\n            memory_info = process.memory_info()\n            print(f\"Step {self.step_counter}: Memory usage: {memory_info.rss / 1024 / 1024:.2f} MB, Time since last log: {current_time - self.last_log_time:.2f}s\")\n            self.last_log_time = current_time\n        \n        # Extract labels\n        labels = inputs.pop(\"labels\")\n        \n        # Forward pass\n        outputs = model(**inputs)\n        logits = outputs.logits\n        \n        # Use class weights in the loss calculation\n        loss_fct = torch.nn.CrossEntropyLoss(weight=class_weights)\n        loss = loss_fct(logits.view(-1, self.model.config.num_labels), labels.view(-1))\n        \n        return (loss, outputs) if return_outputs else loss\n\n# Define training arguments with reduced parameters for debugging\ntraining_args = TrainingArguments(\n    output_dir=\"./results\",\n    num_train_epochs=NUM_EPOCHS,\n    per_device_train_batch_size=BATCH_SIZE,\n    per_device_eval_batch_size=BATCH_SIZE*2,\n    warmup_steps=WARMUP_STEPS,\n    weight_decay=WEIGHT_DECAY,\n    learning_rate=LEARNING_RATE,\n    gradient_accumulation_steps=GRADIENT_ACCUMULATION_STEPS,\n    eval_strategy=\"steps\",  # Changed from epoch to steps for more frequent evaluation\n    eval_steps=1000,  # Evaluate every 100 steps\n    save_strategy=\"steps\",\n    save_steps=1000,  # Save every 100 steps\n    load_best_model_at_end=True,\n    metric_for_best_model=\"f1\",\n    greater_is_better=True,\n    logging_dir=\"./logs\",\n    logging_steps=1000,  # Log every 10 steps for more visibility\n    save_total_limit=2,\n    fp16=True,  # Disable fp16 for CPU training\n    report_to=\"none\",\n    # Add debug options\n    disable_tqdm=False,  # Show progress bars\n    dataloader_num_workers=2,  # No multiprocessing for debugging\n    dataloader_pin_memory=True  # Disable pin memory for debugging\n)\n\n# Define early stopping callback\nearly_stopping_callback = EarlyStoppingCallback(\n    early_stopping_patience=3,\n    early_stopping_threshold=0.01\n)\n\n# Define compute_metrics function for evaluation\ndef compute_metrics(pred):\n    labels = pred.label_ids\n    preds = pred.predictions.argmax(-1)\n    precision, recall, f1, _ = precision_recall_fscore_support(labels, preds, average='weighted')\n    acc = accuracy_score(labels, preds)\n    return {\n        'accuracy': acc,\n        'f1': f1,\n        'precision': precision,\n        'recall': recall\n    }\n\n# Create data collator for padding\ndata_collator = DataCollatorWithPadding(tokenizer=tokenizer, padding='longest')\n\n# Create trainer with debug capabilities\ntrainer = DebugTrainer(\n    model=model,\n    args=training_args,\n    train_dataset=tokenized_train_data,\n    eval_dataset=tokenized_val_data,\n    tokenizer=tokenizer,\n    data_collator=data_collator,\n    compute_metrics=compute_metrics,\n    callbacks=[early_stopping_callback]\n)\n\nprint(\"Training setup complete\")\n",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "# Function to monitor system resources during training\ndef monitor_resources():\n    process = psutil.Process(os.getpid())\n    memory_info = process.memory_info()\n    mem = psutil.virtual_memory()\n    cpu_percent = psutil.cpu_percent(interval=0.1)\n    \n    print(f\"\\nSystem Resources:\")\n    print(f\"CPU Usage: {cpu_percent}%\")\n    print(f\"Process Memory: {memory_info.rss / 1024 / 1024:.2f} MB\")\n    print(f\"System Memory: {mem.percent}% used, {mem.available / 1024 / 1024:.2f} MB available\\n\")\n\n# Run training with more detailed monitoring\ntry:\n    print(\"Starting training...\")\n    \n    # Monitor resources before training\n    print(\"Resources before training:\")\n    monitor_resources()\n    \n    # Start training with a timeout\n    start_time = time.time()\n    \n    # Run training\n    train_result = trainer.train()\n    \n    # Monitor resources after training\n    print(\"Resources after training:\")\n    monitor_resources()\n    \n    # Print training results\n    print(f\"Training completed in {train_result.metrics['train_runtime']:.2f} seconds\")\n    print(f\"Training loss: {train_result.metrics['train_loss']:.4f}\")\n    \n    # Save the model\n    trainer.save_model(\"./final_model\")\n    print(\"Model saved to ./final_model\")\n    \n    # Clean up memory\n    cleanup_memory()\n    \nexcept Exception as e:\n    print(f\"Error during training: {e}\")\n    \n    # Print stack trace for debugging\n    import traceback\n    traceback.print_exc()\n    \n    # Monitor resources after error\n    print(\"Resources after error:\")\n    monitor_resources()\n    \n    raise\n",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  }
+ ]
+}


### PR DESCRIPTION
## Problem
When using the codebert-retrain notebook with MAX_LENGTH set to 10000, a runtime error occurs:
```
RuntimeError: The expanded size of the tensor (10000) must match the existing size (514) at non-singleton dimension 1. Target sizes: [16, 10000]. Tensor sizes: [1, 514]
```

This happens because the token_type_ids buffer size (514) doesn't match the extended position embeddings size (10000).

## Solution
This PR adds a fix that extends the token_type_ids buffer to match the MAX_LENGTH (10000) by:
1. Creating a new buffer with the correct size
2. Copying the original values
3. Registering the new buffer with the model

The fix is minimal and doesn't require custom model classes or changes to the existing code structure.

## Changes
- Added a new notebook file `codebert-retrain-fixed.ipynb` with the fix
- The fix is inserted right after extending the position embeddings
- Updated the notebook title to indicate it's a fixed version

## Testing
The fix has been tested and resolves the runtime error when using extended position embeddings.